### PR TITLE
fix: Return `error` from `ExecuteCustomIO`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,11 +19,11 @@ func Execute() {
 	}
 }
 
-func ExecuteCustomIO(args []string, output io.Writer) {
+func ExecuteCustomIO(args []string, output io.Writer) error {
 	rootCmd.SetArgs(args)
 	rootCmd.SetOutput(output)
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
I was accidently calling `os.Exit` from `ExecuteCustomIO` when error occurs.
This led to sudden termination of caller's program.

This fixes it and returns `error` instead.