### PR TITLE
feat(zalgo): Optional number of added diacritics

### DIFF
--- a/cmd/zalgo.go
+++ b/cmd/zalgo.go
@@ -7,21 +7,36 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewZalgoCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "zalgo word...",
-		Aliases: []string{"z"},
-		Short:   "Turn input words into criptic zalgo text",
-		Long: `Turn input words into criptic zalgo text.
+const (
+	zalgoUse   = "zalgo word..."
+	zalgoShort = "Turn input words into criptic zalgo text"
+	zalgoLong  = `Turn input words into criptic zalgo text.
 
-Zalgo text is digital text that has been modified with combining characters,
-Unicode symbols used to add diacritics above or below letters, to appear
-frightening or glitchy.`,
-		Example: "encodor zalgo Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn",
+Zalgo text is digital text that has been modified with combining characters, Unicode symbols used to add diacritics above or below letters, to appear frightening or glitchy.`
+	zalgoExample    = "encodor zalgo -d 3 Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn"
+	diacriticsUsage = `How many diacritics are added to each letter. Should be 1 <= diacritics <= 3`
+)
+
+func NewZalgoCmd() *cobra.Command {
+	zalgoCmd := &cobra.Command{
+		Use:     zalgoUse,
+		Aliases: []string{"z"},
+		Short:   zalgoShort,
+		Long:    zalgoLong,
+		Example: zalgoExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			text := strings.Join(args, " ")
-			encoded := zalgo.Encode(text)
+			strength, flgErr := cmd.Flags().GetInt8("diacritics")
+			if flgErr != nil {
+				cmd.PrintErr(flgErr)
+			}
+			encoded, encodingErr := zalgo.Encode(text, strength)
+			if encodingErr != nil {
+				cmd.PrintErr(encodingErr)
+			}
 			cmd.Println(encoded)
 		},
 	}
+	zalgoCmd.Flags().Int8P("diacritics", "d", 1, diacriticsUsage)
+	return zalgoCmd
 }

--- a/cmd/zalgo.go
+++ b/cmd/zalgo.go
@@ -12,9 +12,16 @@ const (
 	zalgoShort = "Turn input words into criptic zalgo text"
 	zalgoLong  = `Turn input words into criptic zalgo text.
 
-Zalgo text is digital text that has been modified with combining characters, Unicode symbols used to add diacritics above or below letters, to appear frightening or glitchy.`
+Zalgo text is digital text that has been modified with combining characters,
+Unicode symbols used to add diacritics above or below letters, to appear
+frightening or glitchy.`
 	zalgoExample    = "encodor zalgo -d 3 Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn"
-	diacriticsUsage = `How many diacritics are added to each letter. Should be 1 <= diacritics <= 3`
+	diacriticsUsage = `How many diacritics are added to each letter.
+Should be 1 <= diacritics <= 5`
+)
+
+const (
+	defaultDiacritics = 3
 )
 
 func NewZalgoCmd() *cobra.Command {
@@ -37,6 +44,6 @@ func NewZalgoCmd() *cobra.Command {
 			cmd.Println(encoded)
 		},
 	}
-	zalgoCmd.Flags().Int8P("diacritics", "d", 1, diacriticsUsage)
+	zalgoCmd.Flags().Int8P("diacritics", "d", defaultDiacritics, diacriticsUsage)
 	return zalgoCmd
 }

--- a/cmd/zalgo.go
+++ b/cmd/zalgo.go
@@ -8,29 +8,20 @@ import (
 )
 
 const (
-	zalgoUse   = "zalgo word..."
-	zalgoShort = "Turn input words into criptic zalgo text"
-	zalgoLong  = `Turn input words into criptic zalgo text.
-
-Zalgo text is digital text that has been modified with combining characters,
-Unicode symbols used to add diacritics above or below letters, to appear
-frightening or glitchy.`
-	zalgoExample    = "encodor zalgo -d 3 Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn"
-	diacriticsUsage = `How many diacritics are added to each letter.
-Should be 1 <= diacritics <= 5`
-)
-
-const (
 	defaultDiacritics = 3
 )
 
 func NewZalgoCmd() *cobra.Command {
 	zalgoCmd := &cobra.Command{
-		Use:     zalgoUse,
+		Use:     "zalgo word...",
 		Aliases: []string{"z"},
-		Short:   zalgoShort,
-		Long:    zalgoLong,
-		Example: zalgoExample,
+		Short:   "Turn input words into criptic zalgo text",
+		Long: `Turn input words into criptic zalgo text.
+
+Zalgo text is digital text that has been modified with combining characters,
+Unicode symbols used to add diacritics above or below letters, to appear
+frightening or glitchy.`,
+		Example: "encodor zalgo -d 3 Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn",
 		Run: func(cmd *cobra.Command, args []string) {
 			text := strings.Join(args, " ")
 			strength, flgErr := cmd.Flags().GetInt8("diacritics")
@@ -44,6 +35,11 @@ func NewZalgoCmd() *cobra.Command {
 			cmd.Println(encoded)
 		},
 	}
-	zalgoCmd.Flags().Int8P("diacritics", "d", defaultDiacritics, diacriticsUsage)
+	zalgoCmd.Flags().Int8P(
+		"diacritics",
+		"d",
+		defaultDiacritics,
+		`How many diacritics are added to each letter.
+Should be 1 <= diacritics <= 5`)
 	return zalgoCmd
 }

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -15,6 +15,11 @@ import (
 	"github.com/kirillmorozov/encodor/utils"
 )
 
+const (
+	minDiacritics = 1
+	maxDiacritics = 5
+)
+
 var highDiacritics = []rune{
 	'\u030d', '\u030e', '\u0304', '\u0305', '\u033f', '\u0311', '\u0306',
 	'\u0310', '\u0352', '\u0357', '\u0351', '\u0307', '\u0308', '\u030a',
@@ -47,8 +52,8 @@ var lowDiacritics = []rune{
 // Hashtags(words beginning with `#`) and mentions(words beginning with `@`) are
 // left as is.
 func Encode(text string, diacritics int8) (string, error) {
-	if (diacritics < 1) || (diacritics > 3) {
-		return "", errors.New("Incorrect number of diacritics, should be 1 <= diacritics <= 3")
+	if (diacritics < minDiacritics) || (diacritics > maxDiacritics) {
+		return "", errors.New("Incorrect number of diacritics, should be 1 <= diacritics <= 5")
 	}
 	words := strings.Fields(text)
 	for wordIndex := range words {

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -7,6 +7,7 @@
 package zalgo
 
 import (
+	"errors"
 	"math/rand"
 	"strings"
 	"unicode"
@@ -45,28 +46,33 @@ var lowDiacritics = []rune{
 //
 // Hashtags(words beginning with `#`) and mentions(words beginning with `@`) are
 // left as is.
-func Encode(text string) string {
+func Encode(text string, diacritics int8) (string, error) {
+	if (diacritics < 1) || (diacritics > 3) {
+		return "", errors.New("Incorrect number of diacritics, should be 1 <= diacritics <= 3")
+	}
 	words := strings.Fields(text)
 	for wordIndex := range words {
 		if utils.IsSpecialWord(words[wordIndex]) {
 			continue
 		}
-		words[wordIndex] = encodeWord(words[wordIndex])
+		words[wordIndex] = encodeWord(words[wordIndex], diacritics)
 	}
-	return strings.Join(words, " ")
+	return strings.Join(words, " "), nil
 }
 
-func encodeWord(word string) string {
+func encodeWord(word string, diacritics int8) string {
 	encodedWord := make([]rune, 0, 3*len(word))
 	for _, r := range word {
 		encodedWord = append(encodedWord, r)
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			encodedWord = append(
-				encodedWord,
-				randZalgo(highDiacritics),
-				randZalgo(midDiacritics),
-				randZalgo(lowDiacritics),
-			)
+			for i := int8(0); i < diacritics; i++ {
+				encodedWord = append(
+					encodedWord,
+					randZalgo(highDiacritics),
+					randZalgo(midDiacritics),
+					randZalgo(lowDiacritics),
+				)
+			}
 		}
 	}
 	return string(encodedWord)

--- a/zalgo/zalgo_test.go
+++ b/zalgo/zalgo_test.go
@@ -39,7 +39,7 @@ func BenchmarkEncode(b *testing.B) {
 	for _, bench := range utils.EncodeBenchmarks {
 		b.Run(bench.Name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				Encode(bench.Text, 1)
+				_, _ = Encode(bench.Text, 1)
 			}
 		})
 	}

--- a/zalgo/zalgo_test.go
+++ b/zalgo/zalgo_test.go
@@ -28,7 +28,7 @@ func TestEncode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Encode(tt.args.text); got != tt.want {
+			if got, _ := Encode(tt.args.text, 1); got != tt.want {
 				t.Errorf("Encode() = %v, want %v", got, tt.want)
 			}
 		})
@@ -39,7 +39,7 @@ func BenchmarkEncode(b *testing.B) {
 	for _, bench := range utils.EncodeBenchmarks {
 		b.Run(bench.Name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				Encode(bench.Text)
+				Encode(bench.Text, 1)
 			}
 		})
 	}


### PR DESCRIPTION
Add `diacritics` argument to `Encode` function to control how many
diacritics are added to each letter.

Add `-d`, `--diacritics` flag to cmd to control how many diacritics are
added to each letter. (default 3)