### PR TITLE
pref(zalgo): ~1.5x increase

### DIFF
--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -57,13 +57,12 @@ func Encode(text string, diacritics int8) (string, error) {
 	}
 	var encodedTextBuilder strings.Builder
 	encodedTextBuilder.Grow(len(text))
-	words := strings.Fields(text)
-	for wordIndex := range words {
-		if utils.IsSpecialWord(words[wordIndex]) {
-			encodedTextBuilder.WriteString(words[wordIndex])
+	for _, word := range strings.Fields(text) {
+		if utils.IsSpecialWord(word) {
+			encodedTextBuilder.WriteString(word)
 			continue
 		}
-		encodedTextBuilder.WriteString(encodeWord(words[wordIndex], diacritics))
+		encodedTextBuilder.WriteString(encodeWord(word, diacritics))
 	}
 	return encodedTextBuilder.String(), nil
 }

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -56,7 +56,7 @@ func Encode(text string, diacritics int8) (string, error) {
 		return "", errors.New("Incorrect number of diacritics, should be 1 <= diacritics <= 5")
 	}
 	var encodedTextBuilder strings.Builder
-	encodedTextBuilder.Grow(len(text))
+	encodedTextBuilder.Grow(len(text) * 3 * int(diacritics))
 	for _, word := range strings.Fields(text) {
 		if utils.IsSpecialWord(word) {
 			encodedTextBuilder.WriteString(word)

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -55,18 +55,22 @@ func Encode(text string, diacritics int8) (string, error) {
 	if (diacritics < minDiacritics) || (diacritics > maxDiacritics) {
 		return "", errors.New("Incorrect number of diacritics, should be 1 <= diacritics <= 5")
 	}
+	var encodedTextBuilder strings.Builder
+	encodedTextBuilder.Grow(len(text))
 	words := strings.Fields(text)
 	for wordIndex := range words {
 		if utils.IsSpecialWord(words[wordIndex]) {
+			encodedTextBuilder.WriteString(words[wordIndex])
 			continue
 		}
-		words[wordIndex] = encodeWord(words[wordIndex], diacritics)
+		encodedTextBuilder.WriteString(encodeWord(words[wordIndex], diacritics))
 	}
-	return strings.Join(words, " "), nil
+	return encodedTextBuilder.String(), nil
 }
 
 func encodeWord(word string, diacritics int8) string {
 	var encodedWordBuilder strings.Builder
+	encodedWordBuilder.Grow(len(word) * 3 * int(diacritics))
 	for _, r := range word {
 		encodedWordBuilder.WriteRune(r)
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -66,21 +66,18 @@ func Encode(text string, diacritics int8) (string, error) {
 }
 
 func encodeWord(word string, diacritics int8) string {
-	encodedWord := make([]rune, 0, 3*len(word))
+	var encodedWordBuilder strings.Builder
 	for _, r := range word {
-		encodedWord = append(encodedWord, r)
+		encodedWordBuilder.WriteRune(r)
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			for i := int8(0); i < diacritics; i++ {
-				encodedWord = append(
-					encodedWord,
-					randZalgo(highDiacritics),
-					randZalgo(midDiacritics),
-					randZalgo(lowDiacritics),
-				)
+				encodedWordBuilder.WriteRune(randZalgo(highDiacritics))
+				encodedWordBuilder.WriteRune(randZalgo(midDiacritics))
+				encodedWordBuilder.WriteRune(randZalgo(lowDiacritics))
 			}
 		}
 	}
-	return string(encodedWord)
+	return encodedWordBuilder.String()
 }
 
 // randZalgo gets a random char from a zalgo char table

--- a/zalgo/zalgo.go
+++ b/zalgo/zalgo.go
@@ -62,25 +62,18 @@ func Encode(text string, diacritics int8) (string, error) {
 			encodedTextBuilder.WriteString(word)
 			continue
 		}
-		encodedTextBuilder.WriteString(encodeWord(word, diacritics))
-	}
-	return encodedTextBuilder.String(), nil
-}
-
-func encodeWord(word string, diacritics int8) string {
-	var encodedWordBuilder strings.Builder
-	encodedWordBuilder.Grow(len(word) * 3 * int(diacritics))
-	for _, r := range word {
-		encodedWordBuilder.WriteRune(r)
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			for i := int8(0); i < diacritics; i++ {
-				encodedWordBuilder.WriteRune(randZalgo(highDiacritics))
-				encodedWordBuilder.WriteRune(randZalgo(midDiacritics))
-				encodedWordBuilder.WriteRune(randZalgo(lowDiacritics))
+		for _, r := range word {
+			encodedTextBuilder.WriteRune(r)
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				for i := int8(0); i < diacritics; i++ {
+					encodedTextBuilder.WriteString(
+						string(randZalgo(highDiacritics) + randZalgo(midDiacritics) + randZalgo(lowDiacritics)),
+					)
+				}
 			}
 		}
 	}
-	return encodedWordBuilder.String()
+	return encodedTextBuilder.String(), nil
 }
 
 // randZalgo gets a random char from a zalgo char table


### PR DESCRIPTION
Increase performance by ~1.5 times and significantly reduce allocations.

Benchmark results before:

```
goos: darwin
goarch: arm64
pkg: github.com/kirillmorozov/encodor/zalgo
BenchmarkEncode/Multiline-10              654084              1834 ns/op            1632 B/op         14 allocs/op
BenchmarkEncode/Lorem_Ipsum-10             43747             27195 ns/op           21240 B/op        209 allocs/op
```

And after:

```
goos: darwin
goarch: arm64
pkg: github.com/kirillmorozov/encodor/zalgo
BenchmarkEncode/Multiline-10              984074              1211 ns/op             352 B/op          2 allocs/op
BenchmarkEncode/Lorem_Ipsum-10             70178             16984 ns/op            4608 B/op          3 allocs/op
```