### PR TITLE
perf(beghilosz): ~25% increase

### DIFF
--- a/beghilosz/beghilosz.go
+++ b/beghilosz/beghilosz.go
@@ -14,36 +14,36 @@ import (
 	"github.com/kirillmorozov/encodor/utils"
 )
 
-// Encode transforms text into calculator spelling.
+var beghiloszReplacer = strings.NewReplacer(
+	"B", "8",
+	"E", "3",
+	"G", "6",
+	"H", "4",
+	"I", "1",
+	"L", "7",
+	"O", "0",
+	"S", "5",
+	"Z", "2",
+)
+
+// Encode encodes text into calculator spelling.
 //
-// Hashtags(words beginning with `#`) and mentions(words beginning with `@`) are
+// Special words(as determined by utils.IsSpecialWord) are
 // left as is.
 func Encode(text string) string {
-	beghiloszReplacer := strings.NewReplacer(
-		"B", "8",
-		"E", "3",
-		"G", "6",
-		"H", "4",
-		"I", "1",
-		"L", "7",
-		"O", "0",
-		"S", "5",
-		"Z", "2",
-	)
 	text = strings.ToUpper(text)
-	lines := strings.Split(text, "\n")
-	for lineIndex, line := range lines {
-		words := strings.Fields(line)
-		for wordIndex, word := range words {
-			if !utils.IsSpecialWord(word) {
-				word = beghiloszReplacer.Replace(word)
-				word = utils.ReverseString(word)
-			}
-			words[wordIndex] = word
+	words := strings.Fields(text)
+	var builder strings.Builder
+	builder.Grow(len(text))
+	for i := len(words) - 1; i >= 0; i-- {
+		if !utils.IsSpecialWord(words[i]) {
+			words[i] = beghiloszReplacer.Replace(words[i])
+			words[i] = utils.ReverseString(words[i])
 		}
-		words = utils.ReverseStringSlice(words)
-		lines[lineIndex] = strings.Join(words, " ")
+		builder.WriteString(words[i])
+		if i != 0 {
+			builder.WriteString(" ")
+		}
 	}
-	lines = utils.ReverseStringSlice(lines)
-	return strings.Join(lines, "\n")
+	return builder.String()
 }

--- a/beghilosz/beghilosz.go
+++ b/beghilosz/beghilosz.go
@@ -32,7 +32,7 @@ var beghiloszReplacer = strings.NewReplacer(
 // left as is.
 func Encode(text string) string {
 	text = strings.ToUpper(text)
-	words := strings.Fields(text)
+	words := strings.Split(text, " ")
 	var builder strings.Builder
 	builder.Grow(len(text))
 	for i := len(words) - 1; i >= 0; i-- {

--- a/beghilosz/beghilosz_test.go
+++ b/beghilosz/beghilosz_test.go
@@ -40,11 +40,11 @@ func TestEncode(t *testing.T) {
 			args: args{"Sentence with a #hashtag"},
 			want: "#HASHTAG A 4T1W 3CN3TN35",
 		},
-		// {
-		// 	name: "Multiline text",
-		// 	args: args{"Line 1\nLine 2"},
-		// 	want: "2 3N17\n1 3N17",
-		// },
+		{
+			name: "Multiline text",
+			args: args{"Line 1\nLine 2"},
+			want: "2 3N17\n1 3N17",
+		},
 		{
 			name: "Cyrilic",
 			args: args{"привет"},

--- a/beghilosz/beghilosz_test.go
+++ b/beghilosz/beghilosz_test.go
@@ -40,10 +40,15 @@ func TestEncode(t *testing.T) {
 			args: args{"Sentence with a #hashtag"},
 			want: "#HASHTAG A 4T1W 3CN3TN35",
 		},
+		// {
+		// 	name: "Multiline text",
+		// 	args: args{"Line 1\nLine 2"},
+		// 	want: "2 3N17\n1 3N17",
+		// },
 		{
-			name: "Multiline text",
-			args: args{"Line 1\nLine 2"},
-			want: "2 3N17\n1 3N17",
+			name: "Cyrilic",
+			args: args{"привет"},
+			want: "ТЕВИРП",
 		},
 	}
 	for _, tt := range tests {
@@ -58,6 +63,7 @@ func TestEncode(t *testing.T) {
 func BenchmarkEncode(b *testing.B) {
 	for _, bench := range utils.EncodeBenchmarks {
 		b.Run(bench.Name, func(b *testing.B) {
+			b.SetBytes(int64(len(bench.Text)))
 			for i := 0; i < b.N; i++ {
 				Encode(bench.Text)
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/kirillmorozov/encodor
 
-go 1.16
+go 1.17
 
 require github.com/spf13/cobra v1.4.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,11 +21,3 @@ func ReverseString(str string) string {
 	}
 	return string(rns)
 }
-
-// ReverseStringSlice reverse strings order in slice.
-func ReverseStringSlice(slice []string) []string {
-	for i := 0; i < len(slice)/2; i++ {
-		slice[i], slice[len(slice)-1-i] = slice[len(slice)-1-i], slice[i]
-	}
-	return slice
-}


### PR DESCRIPTION
### Benchmarks

Here are benchstat results when compared to 08ba9e7c26708120ed51e5b0f207d0b7d70212e9.

```
name                   old time/op    new time/op    delta
Encode/Multiline-10      1.13µs ± 1%    0.62µs ± 0%  -45.68%  (p=0.000 n=9+10)
Encode/Lorem_Ipsum-10    8.23µs ± 1%    8.01µs ± 1%   -2.77%  (p=0.000 n=10+10)
[Geo mean]               3.05µs         2.22µs       -27.33%

name                   old alloc/op   new alloc/op   delta
Encode/Multiline-10      1.15kB ± 0%    0.37kB ± 0%  -68.06%  (p=0.000 n=10+10)
Encode/Lorem_Ipsum-10    4.58kB ± 0%    3.92kB ± 0%  -14.34%  (p=0.000 n=10+10)
[Geo mean]               2.30kB         1.20kB       -47.69%

name                   old allocs/op  new allocs/op  delta
Encode/Multiline-10        22.0 ± 0%      12.0 ± 0%  -45.45%  (p=0.000 n=10+10)
Encode/Lorem_Ipsum-10       206 ± 0%       202 ± 0%   -1.94%  (p=0.000 n=10+10)
[Geo mean]                 67.3           49.2       -26.87%
```